### PR TITLE
Add support for Flow framework version 4

### DIFF
--- a/Tideways.php
+++ b/Tideways.php
@@ -501,6 +501,7 @@ class Profiler
     const FRAMEWORK_DRUPAL8            = 'drupal8';
     const FRAMEWORK_TYPO3              = 'typo3';
     const FRAMEWORK_FLOW               = 'flow';
+    const FRAMEWORK_FLOW4              = 'flow4';
     const FRAMEWORK_CAKE2              = 'cake2';
     const FRAMEWORK_CAKE3              = 'cake3';
     const FRAMEWORK_YII                = 'yii';
@@ -630,6 +631,11 @@ class Profiler
             case self::FRAMEWORK_FLOW:
                 self::$defaultOptions['transaction_function'] = 'TYPO3\Flow\Mvc\Controller\ActionController::callActionMethod';
                 self::$defaultOptions['exception_function'] = 'TYPO3\Flow\Error\AbstractExceptionHandler::handleException';
+                break;
+
+            case self::FRAMEWORK_FLOW4:
+                self::$defaultOptions['transaction_function'] = 'Neos\Flow\Mvc\Controller\ActionController::callActionMethod';
+                self::$defaultOptions['exception_function'] = 'Neos\Flow\Error\AbstractExceptionHandler::handleException';
                 break;
 
             case self::FRAMEWORK_TYPO3:

--- a/Tideways.php
+++ b/Tideways.php
@@ -629,12 +629,12 @@ class Profiler
                 break;
 
             case self::FRAMEWORK_FLOW:
-                self::$defaultOptions['transaction_function'] = 'TYPO3\Flow\Mvc\Controller\ActionController::callActionMethod';
+                self::$defaultOptions['transaction_function'] = 'TYPO3\Flow\Mvc\Controller\ActionController_Original::callActionMethod';
                 self::$defaultOptions['exception_function'] = 'TYPO3\Flow\Error\AbstractExceptionHandler::handleException';
                 break;
 
             case self::FRAMEWORK_FLOW4:
-                self::$defaultOptions['transaction_function'] = 'Neos\Flow\Mvc\Controller\ActionController::callActionMethod';
+                self::$defaultOptions['transaction_function'] = 'Neos\Flow\Mvc\Controller\ActionController_Original::callActionMethod';
                 self::$defaultOptions['exception_function'] = 'Neos\Flow\Error\AbstractExceptionHandler::handleException';
                 break;
 


### PR DESCRIPTION
The vendor name was changed with Flow 4, so this needs to be supported.
This is achieved by adding a new `framework` option `flow4` to do this.

Also, the method used for detection is defined in a "clone" of the source class
that has _Original appended to it's name. Since a straight match is done, the
comparison needs to be done against the name of that "clone".